### PR TITLE
persisting hostname changes; cleaning up apt pkg after install

### DIFF
--- a/zabbix-agent/README.md
+++ b/zabbix-agent/README.md
@@ -21,7 +21,7 @@ Example
 ansible -v $HOST_PRIVATE_IP -i $HOST_PRIVATE_IP, \
   --user=$HOST_USER \
   --key-file=$HOST_PRIVATE_KEY \
-  --extra-vars="zabbix_major_version=$ZABBIX_MAJOR_VERSION" \
+  --extra-vars="zabbix_major_version=$ZABBIX_MAJOR_VERSION zabbix_server=$ZABBIX_SERVER" \
   --module-name=import_role --args name=zabbix-agent
 ```
 

--- a/zabbix-agent/README.md
+++ b/zabbix-agent/README.md
@@ -21,6 +21,7 @@ Example
 ansible -v $HOST_PRIVATE_IP -i $HOST_PRIVATE_IP, \
   --user=$HOST_USER \
   --key-file=$HOST_PRIVATE_KEY \
+  --extra-vars="zabbix_major_version=$ZABBIX_MAJOR_VERSION" \
   --module-name=import_role --args name=zabbix-agent
 ```
 

--- a/zabbix-agent/files/zabbix_agentd.conf.j2
+++ b/zabbix-agent/files/zabbix_agentd.conf.j2
@@ -95,7 +95,7 @@ LogFileSize=0
 # Default:
 # Server=
 
-Server={{ zabbix_server }}
+Server={{ zabbix_server_domain_name }}
 
 ### Option: ListenPort
 #	Agent will listen on this port for connections from the server.
@@ -136,7 +136,7 @@ Server={{ zabbix_server }}
 # Default:
 # ServerActive=
 
-ServerActive={{ zabbix_server }}
+ServerActive={{ zabbix_server_domain_name }}
 
 ### Option: Hostname
 #	Unique, case sensitive hostname.

--- a/zabbix-agent/install_on_all_ec2.py
+++ b/zabbix-agent/install_on_all_ec2.py
@@ -98,7 +98,7 @@ def install_zabbix_agent_with_ansible(instance_to_run, ssl_keys_directory, zabbi
             ansible {instance_to_run['private_ip']} -i {instance_to_run['private_ip']}, \
                 --user={user_to_run} \
                 --key-file={get_key_file(instance_to_run, ssl_keys_directory)} \
-                --extra-vars="zabbix_major_version={zabbix_major_version}" \
+                --extra-vars="zabbix_major_version={zabbix_major_version} zabbix_server={os.environ['ZABBIX_SERVER']}" \
                 --module-name=import_role \
                 --args name=zabbix-agent
             """,

--- a/zabbix-agent/tasks/deploy-zabbix-agent.yml
+++ b/zabbix-agent/tasks/deploy-zabbix-agent.yml
@@ -4,7 +4,7 @@
     dest: /etc/zabbix/zabbix_agentd.conf
     owner: zabbix
   vars:
-    zabbix_server: "{{ lookup('env', 'ZABBIX_SERVER') | regex_replace('^https://(.*)$', '\\1') }}"
+    zabbix_server_domain_name: "{{ zabbix_server | regex_replace('^(https|http):\/\/(.*)$', '\\2') }}"
 
 - name: create zabbix-agent log dir
   file:

--- a/zabbix-agent/tasks/install-apt.yml
+++ b/zabbix-agent/tasks/install-apt.yml
@@ -17,6 +17,7 @@
     wget https://repo.zabbix.com/zabbix/{{ zabbix_major_version }}/ubuntu/pool/main/z/zabbix-release/$ZABBIX_RELEASE_DEB
     dpkg -i $ZABBIX_RELEASE_DEB
     apt-get update
+    rm $ZABBIX_RELEASE_DEB
 
 - name: install zabbix-agent (apt)
   become: yes

--- a/zabbix-agent/tasks/set-hostname.yml
+++ b/zabbix-agent/tasks/set-hostname.yml
@@ -3,10 +3,11 @@
     hostname_to_change: "{{ instance_name | replace('_', '') }}-{{ private_ip }}"
 
 - name: set new instance hostname
-  command: "hostname {{ hostname_to_change }}"
+  command: "hostnamectl set-hostname {{ hostname_to_change }}"
 
 - name: add new hostname to hosts
   shell: |
     {
       echo '127.0.0.1 {{ hostname_to_change }}'
     } >> /etc/hosts
+    sort /etc/hosts | uniq > /etc/hosts


### PR DESCRIPTION
When restarting an EC2 instance with previously installed zabbix-agent in it, the hostname would fall back to the aws default
